### PR TITLE
Fix updateCMSFields for ProductVariation

### DIFF
--- a/code/Extensions/TrackStockOnBuyable.php
+++ b/code/Extensions/TrackStockOnBuyable.php
@@ -144,10 +144,11 @@ class TrackStockOnBuyable extends DataExtension
 
         if ($write) {
             $this->owner->write();
-
-            $stages = $this->owner->getVersionedStages();
             
-            if ($this->owner->hasExtension('Versioned') && in_array("Stage", $stages)) {
+            if (
+                $this->owner->hasExtension('Versioned') &&
+                in_array("Stage", $this->owner->getVersionedStages())
+            ) {
                 $this->owner->writeToStage('Stage');
                 $this->owner->publish('Stage', 'Live');
             }
@@ -196,9 +197,10 @@ class TrackStockOnBuyable extends DataExtension
         if ($write) {
             $this->owner->write();
 
-            $stages = $this->owner->getVersionedStages();
-
-            if ($this->owner->hasExtension('Versioned') && in_array("Stage", $stages)) {
+            if (
+                $this->owner->hasExtension('Versioned') &&
+                in_array("Stage", $this->owner->getVersionedStages())
+            ) {
                 $this->owner->writeToStage('Stage');
                 $this->owner->publish('Stage', 'Live');
             }

--- a/code/Extensions/TrackStockOnBuyable.php
+++ b/code/Extensions/TrackStockOnBuyable.php
@@ -145,7 +145,9 @@ class TrackStockOnBuyable extends DataExtension
         if ($write) {
             $this->owner->write();
 
-            if ($this->owner->hasExtension('Versioned')) {
+            $stages = $this->owner->getVersionedStages();
+            
+            if ($this->owner->hasExtension('Versioned') && in_array("Stage", $stages)) {
                 $this->owner->writeToStage('Stage');
                 $this->owner->publish('Stage', 'Live');
             }
@@ -194,7 +196,9 @@ class TrackStockOnBuyable extends DataExtension
         if ($write) {
             $this->owner->write();
 
-            if ($this->owner->hasExtension('Versioned')) {
+            $stages = $this->owner->getVersionedStages();
+
+            if ($this->owner->hasExtension('Versioned') && in_array("Stage", $stages)) {
                 $this->owner->writeToStage('Stage');
                 $this->owner->publish('Stage', 'Live');
             }

--- a/code/Extensions/TrackStockOnBuyable.php
+++ b/code/Extensions/TrackStockOnBuyable.php
@@ -73,31 +73,29 @@ class TrackStockOnBuyable extends DataExtension
             return;
         }
 
-        $fields->addFieldToTab(
-            'Root.Main',
-            FieldGroup::create(
-                _t('ShopInventory.' . $this->stockField, FormField::name_to_label($this->stockField)),
-                [
-                    NumericField::create($this->stockField, ''),
-                    ToggleCompositeField::create($this->stockField . '_Options',
-                        _t('ShopInventory.STOCK_OPTIONS', 'Options'),
-                        [
-                            DropdownField::create($this->stockField . '_NoTracking', '', [
-                                0 => _t('ShopInventory.TRACK_INVENTORY', 'Track inventory'),
-                                1 => _t('ShopInventory.NO_TRACK_INVENTORY', "Don't track inventory"),
-                            ]),
-                            CheckboxField::create($this->stockField . '_AlwaysAllow',
-                                _t('ShopInventory.ALWAYS_ALLOW_PURCHASE',
-                                    'Always allow purchase even when out of stock')),
-                        ]
-                    )->setHeadingLevel(5),
-                ]
-            )->setName($this->stockField . '_Tab'),
-            'Content'
-        );
+        $fieldgroup = FieldGroup::create(
+            _t('ShopInventory.' . $this->stockField, FormField::name_to_label($this->stockField)),
+            [
+                NumericField::create($this->stockField, ''),
+                ToggleCompositeField::create($this->stockField . '_Options',
+                    _t('ShopInventory.STOCK_OPTIONS', 'Options'),
+                    [
+                        DropdownField::create($this->stockField . '_NoTracking', '', [
+                            0 => _t('ShopInventory.TRACK_INVENTORY', 'Track inventory'),
+                            1 => _t('ShopInventory.NO_TRACK_INVENTORY', "Don't track inventory"),
+                        ]),
+                        CheckboxField::create($this->stockField . '_AlwaysAllow',
+                            _t('ShopInventory.ALWAYS_ALLOW_PURCHASE',
+                                'Allow purchase even when out of stock')),
+                    ]
+                )->setHeadingLevel(5),
+            ]
+        )->setName($this->stockField . '_Tab');
 
-        if (!$this->owner->AllowPurchase) {
-            $fields->removeByName($this->stockField . '_AlwaysAllow', true);
+        if($fields->hasTabSet('Root')) {
+            $fields->addFieldToTab('Root.Main', $fieldgroup, 'Content');
+        } else {
+            $fields->push($fieldgroup);
         }
     }
 


### PR DESCRIPTION
TrackStockOnBuyable currently breaks editing ProductVariations due to a
non-existent 'Root' tabset in $fields.

Also removed condition that removes the _AlwaysAllow checkbox. See no
detriment to the user's workflow or experience having this show while
AllowPurchase is false. Changed wording to not indicate this setting
might override other product availability rules.
